### PR TITLE
Revert to noarch and fix fancylog without depending on Python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,12 +18,12 @@ build:
 
 requirements:
   host:
-    - python
+    - python >={{ python_min }}
     - pip
     - setuptools
     - setuptools-scm
   run:
-    - python
+    - python >={{ python_min }}
     - paramiko
     - pyyaml
     - requests
@@ -61,7 +61,7 @@ test:
     - validators
     - filelock       
     - python-dotenv   
-    - python
+    - python >={{ python_min }}
 
 about:
   home: https://datashuttle.neuroinformatics.dev/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,11 @@ source:
   sha256: 451831fda5fb728783285649e7fb548e805243c104e8f7880a5187582cb2aa80
 
 build:
+  noarch: python
   entry_points:
     - "datashuttle = datashuttle.tui_launcher:main"
   script: {{ PYTHON }} -m pip install . -vv --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -27,8 +28,7 @@ requirements:
     - pyyaml
     - requests
     - rich
-    - fancylog >=0.7.0  # [py>=311]
-    - fancylog >=0.4.2,<0.5.0  # [py<311]
+    - fancylog >=0.4.2,!=0.5.*,!=0.6.*
     - simplejson
     - rclone
     - pyperclip


### PR DESCRIPTION
Updated package version number and adjusted fancylog dependency constraints.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
